### PR TITLE
Include LAST_UPDATE_TIME

### DIFF
--- a/templates/__teamSpeakViewerChildChannels.tpl
+++ b/templates/__teamSpeakViewerChildChannels.tpl
@@ -9,7 +9,7 @@
                         {/if}
                     </div>
                     <div class="channelSubscription">
-                        <img src="{$__wcf->getPath()}images/teamspeak_viewer/channel_unsubscribed.svg">
+                        <img src="{$__wcf->getPath()}images/teamspeak_viewer/channel_unsubscribed.svg?v={@LAST_UPDATE_TIME}">
                     </div>
                     <div class="channelName">
                         {assign var='linkParameters' value='1'}
@@ -17,16 +17,16 @@
                     </div>
                     <div class="channelIcons">
                         {if $channel['channel_flag_default'] == 1}
-                            <img src="{$__wcf->getPath()}images/teamspeak_viewer/default.svg">
+                            <img src="{$__wcf->getPath()}images/teamspeak_viewer/default.svg?v={@LAST_UPDATE_TIME}">
                         {/if}
                         {if $channel['channel_flag_password'] == 1}
-                            <img src="{$__wcf->getPath()}images/teamspeak_viewer/register.svg">
+                            <img src="{$__wcf->getPath()}images/teamspeak_viewer/register.svg?v={@LAST_UPDATE_TIME}">
                         {/if}
                         {if $channel['channel_needed_talk_power'] > 0}
-                            <img src="{$__wcf->getPath()}images/teamspeak_viewer/moderated.svg">
+                            <img src="{$__wcf->getPath()}images/teamspeak_viewer/moderated.svg?v={@LAST_UPDATE_TIME}">
                         {/if}
                         {if $channel['channel_icon_id'] != 0}
-                            <img src="{$__wcf->getPath()}images/teamspeak_viewer/icon_{$channel['channel_icon_id']}.png">
+                            <img src="{$__wcf->getPath()}images/teamspeak_viewer/icon_{$channel['channel_icon_id']}.png?v={@LAST_UPDATE_TIME}">
                         {/if}
                     </div>
                 </div>

--- a/templates/__teamSpeakViewerClients.tpl
+++ b/templates/__teamSpeakViewerClients.tpl
@@ -6,23 +6,23 @@
                     <div class="channelCollapse"></div>
                     <div class="channelSubscription">
                         {if $client['client_away'] == 1}
-                            <img src="{$__wcf->getPath()}images/teamspeak_viewer/away.svg">
+                            <img src="{$__wcf->getPath()}images/teamspeak_viewer/away.svg?v={@LAST_UPDATE_TIME}">
                         {else if $client['client_output_hardware'] == 0}
-                            <img src="{$__wcf->getPath()}images/teamspeak_viewer/hardware_output_muted.svg">
+                            <img src="{$__wcf->getPath()}images/teamspeak_viewer/hardware_output_muted.svg?v={@LAST_UPDATE_TIME}">
                         {else if $client['client_output_muted'] == 1}
-                            <img src="{$__wcf->getPath()}images/teamspeak_viewer/output_muted.svg">
+                            <img src="{$__wcf->getPath()}images/teamspeak_viewer/output_muted.svg?v={@LAST_UPDATE_TIME}">
                         {else if $client['client_input_hardware'] == 0}
-                            <img src="{$__wcf->getPath()}images/teamspeak_viewer/hardware_input_muted.svg">
+                            <img src="{$__wcf->getPath()}images/teamspeak_viewer/hardware_input_muted.svg?v={@LAST_UPDATE_TIME}">
                         {else if $client['client_input_muted'] == 1}
-                            <img src="{$__wcf->getPath()}images/teamspeak_viewer/input_muted.svg">
+                            <img src="{$__wcf->getPath()}images/teamspeak_viewer/input_muted.svg?v={@LAST_UPDATE_TIME}">
                         {else if $client['client_flag_talking'] == 1 && $client['client_is_channel_commander'] == 1}
-                            <img src="{$__wcf->getPath()}images/teamspeak_viewer/player_commander_on.svg">
+                            <img src="{$__wcf->getPath()}images/teamspeak_viewer/player_commander_on.svg?v={@LAST_UPDATE_TIME}">
                         {else if $client['client_flag_talking'] == 0 && $client['client_is_channel_commander'] == 1}
-                            <img src="{$__wcf->getPath()}images/teamspeak_viewer/player_commander_off.svg">
+                            <img src="{$__wcf->getPath()}images/teamspeak_viewer/player_commander_off.svg?v={@LAST_UPDATE_TIME}">
                         {else if $client['client_flag_talking'] == 1}
-                            <img src="{$__wcf->getPath()}images/teamspeak_viewer/player_on.svg">
+                            <img src="{$__wcf->getPath()}images/teamspeak_viewer/player_on.svg?v={@LAST_UPDATE_TIME}">
                         {else if $client['client_flag_talking'] == 0}
-                            <img src="{$__wcf->getPath()}images/teamspeak_viewer/player_off.svg">
+                            <img src="{$__wcf->getPath()}images/teamspeak_viewer/player_off.svg?v={@LAST_UPDATE_TIME}">
                         {/if}
                     </div>
                     <div class="channelName{if $client['client_is_recording'] == 1} recording{/if}">
@@ -37,20 +37,20 @@
                     <div class="channelIcons">
                         {if !$client['client_badges']|empty}
                             {foreach from=$client['client_badges'] item=badge}
-                                <img src="{$__wcf->getPath()}images/teamspeak_viewer/badges/{$badge}">
+                                <img src="{$__wcf->getPath()}images/teamspeak_viewer/badges/{$badge}?v={@LAST_UPDATE_TIME}">
                             {/foreach}
                         {/if}
                         {if $client['client_is_priority_speaker'] == 1}
-                            <img src="{$__wcf->getPath()}images/teamspeak_viewer/capture.svg">
+                            <img src="{$__wcf->getPath()}images/teamspeak_viewer/capture.svg?v={@LAST_UPDATE_TIME}">
                         {/if}
                         {if $client['client_is_talker'] == 1}
-                            <img src="{$__wcf->getPath()}images/teamspeak_viewer/is_talker.svg">
+                            <img src="{$__wcf->getPath()}images/teamspeak_viewer/is_talker.svg?v={@LAST_UPDATE_TIME}">
                         {/if}
                         {if !$client['client_channel_group_id']|empty}
-                            <img src="{$__wcf->getPath()}images/teamspeak_viewer/{$client['client_channel_group_id']}">
+                            <img src="{$__wcf->getPath()}images/teamspeak_viewer/{$client['client_channel_group_id']}?v={@LAST_UPDATE_TIME}">
                         {/if}
                         {foreach from=$client['client_servergroups'] item=$servergroup}
-                            <img src="{$__wcf->getPath()}images/teamspeak_viewer/{$servergroup}">
+                            <img src="{$__wcf->getPath()}images/teamspeak_viewer/{$servergroup}?v={@LAST_UPDATE_TIME}">
                         {/foreach}
                     </div>
                 </div>

--- a/templates/teamSpeakClientlistUserPanel.tpl
+++ b/templates/teamSpeakClientlistUserPanel.tpl
@@ -3,23 +3,23 @@
         <div class="box48">
             <div style="flex: 1 1 auto;" class="TeamSpeakClient">
                 {if $client['client_away'] == 1}
-                    <img src="{$__wcf->getPath()}images/teamspeak_viewer/away.svg">
+                    <img src="{$__wcf->getPath()}images/teamspeak_viewer/away.svg?v={@LAST_UPDATE_TIME}">
                 {else if $client['client_output_hardware'] == 0}
-                    <img src="{$__wcf->getPath()}images/teamspeak_viewer/hardware_output_muted.svg">
+                    <img src="{$__wcf->getPath()}images/teamspeak_viewer/hardware_output_muted.svg?v={@LAST_UPDATE_TIME}">
                 {else if $client['client_output_muted'] == 1}
-                    <img src="{$__wcf->getPath()}images/teamspeak_viewer/output_muted.svg">
+                    <img src="{$__wcf->getPath()}images/teamspeak_viewer/output_muted.svg?v={@LAST_UPDATE_TIME}">
                 {else if $client['client_input_hardware'] == 0}
-                    <img src="{$__wcf->getPath()}images/teamspeak_viewer/hardware_input_muted.svg">
+                    <img src="{$__wcf->getPath()}images/teamspeak_viewer/hardware_input_muted.svg?v={@LAST_UPDATE_TIME}">
                 {else if $client['client_input_muted'] == 1}
-                    <img src="{$__wcf->getPath()}images/teamspeak_viewer/input_muted.svg">
+                    <img src="{$__wcf->getPath()}images/teamspeak_viewer/input_muted.svg?v={@LAST_UPDATE_TIME}">
                 {else if $client['client_flag_talking'] == 1 && $client['client_is_channel_commander'] == 1}
-                    <img src="{$__wcf->getPath()}images/teamspeak_viewer/player_commander_on.svg">
+                    <img src="{$__wcf->getPath()}images/teamspeak_viewer/player_commander_on.svg?v={@LAST_UPDATE_TIME}">
                 {else if $client['client_flag_talking'] == 0 && $client['client_is_channel_commander'] == 1}
-                    <img src="{$__wcf->getPath()}images/teamspeak_viewer/player_commander_off.svg">
+                    <img src="{$__wcf->getPath()}images/teamspeak_viewer/player_commander_off.svg?v={@LAST_UPDATE_TIME}">
                 {else if $client['client_flag_talking'] == 1}
-                    <img src="{$__wcf->getPath()}images/teamspeak_viewer/player_on.svg">
+                    <img src="{$__wcf->getPath()}images/teamspeak_viewer/player_on.svg?v={@LAST_UPDATE_TIME}">
                 {else if $client['client_flag_talking'] == 0}
-                    <img src="{$__wcf->getPath()}images/teamspeak_viewer/player_off.svg">
+                    <img src="{$__wcf->getPath()}images/teamspeak_viewer/player_off.svg?v={@LAST_UPDATE_TIME}">
                 {/if}
                 {$client['client_nickname']}
             </div>

--- a/templates/teamSpeakViewer.tpl
+++ b/templates/teamSpeakViewer.tpl
@@ -14,14 +14,14 @@
                 <li data-type="server" data-id="">
                     <div class="channelWrapper">
                         <div class="channelCollapse">
-                            <img src="{$__wcf->getPath()}images/teamspeak_viewer/server.svg">
+                            <img src="{$__wcf->getPath()}images/teamspeak_viewer/server.svg?v={@LAST_UPDATE_TIME}">
                         </div>
                         <div class="channelName">
                             {$serverinfo['virtualserver_name']}
                         </div>
                         <div class="channelIcons">
                             {if $serverinfo['virtualserver_icon_id'] != 0}
-                                <img src="{$__wcf->getPath()}images/teamspeak_viewer/icon_{$serverinfo['virtualserver_icon_id']}.png">
+                                <img src="{$__wcf->getPath()}images/teamspeak_viewer/icon_{$serverinfo['virtualserver_icon_id']}.png?v={@LAST_UPDATE_TIME}">
                             {/if}
                         </div>
                     </div>
@@ -36,7 +36,7 @@
                             </div>
                             {if !$channel['is_spacer']}
                                 <div class="channelSubscription">
-                                    <img src="{$__wcf->getPath()}images/teamspeak_viewer/channel_unsubscribed.svg">
+                                    <img src="{$__wcf->getPath()}images/teamspeak_viewer/channel_unsubscribed.svg?v={@LAST_UPDATE_TIME}">
                                 </div>
                             {/if}
                             <div class="channelName{if $channel['is_spacer']} channelSpacer{$channel['spacer_type']}{/if}">
@@ -44,16 +44,16 @@
                             </div>
                             <div class="channelIcons">
                                 {if $channel['channel_flag_default'] == 1}
-                                    <img src="{$__wcf->getPath()}images/teamspeak_viewer/default.svg">
+                                    <img src="{$__wcf->getPath()}images/teamspeak_viewer/default.svg?v={@LAST_UPDATE_TIME}">
                                 {/if}
                                 {if $channel['channel_flag_password'] == 1}
-                                    <img src="{$__wcf->getPath()}images/teamspeak_viewer/register.svg">
+                                    <img src="{$__wcf->getPath()}images/teamspeak_viewer/register.svg?v={@LAST_UPDATE_TIME}">
                                 {/if}
                                 {if $channel['channel_needed_talk_power'] > 0}
-                                    <img src="{$__wcf->getPath()}images/teamspeak_viewer/moderated.svg">
+                                    <img src="{$__wcf->getPath()}images/teamspeak_viewer/moderated.svg?v={@LAST_UPDATE_TIME}">
                                 {/if}
                                 {if $channel['channel_icon_id'] != 0}
-                                    <img src="{$__wcf->getPath()}images/teamspeak_viewer/icon_{$channel['channel_icon_id']}.png">
+                                    <img src="{$__wcf->getPath()}images/teamspeak_viewer/icon_{$channel['channel_icon_id']}.png?v={@LAST_UPDATE_TIME}">
                                 {/if}
                             </div>
                         </div>


### PR DESCRIPTION
So wird zu strenger Cache wie z.B. durch Cloudflare umgangen, sobald sich die hinterlegte Datei erneuert ohne den Cache zu leeren oder die Konfiguration dafür anzupassen zu müssen. Zusätzlich sollte das auch in der Client Detailansicht so gehandhabt werden. Allerdings wird das ganze via JS ausgeliefert, wenn ich das richtig gesehen habe. Man könnte höchstens den kompletten Cache umgehen und nur den aktuellen timestamp vom Client anhängen.